### PR TITLE
Add rule to create events

### DIFF
--- a/gke/rbac.yaml
+++ b/gke/rbac.yaml
@@ -14,9 +14,9 @@ rules:
 - apiGroups: [""]
   resources: ["endpoints"]
   verbs: ["get"]
-# - apiGroups: [""]
-#   resources: ["events"]
-#   verbs: ["create"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/kind/base/deployment_rbac.yaml
+++ b/kind/base/deployment_rbac.yaml
@@ -1,7 +1,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: endpoint-reader
+  name: rabbitmq-peer-discovery-rbac
  
 rules:
 - apiGroups: 
@@ -12,15 +12,21 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+    - ""
+  resources:
+    - events
+  verbs:
+    - create
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: endpoint-reader
+  name: rabbitmq-peer-discovery-rbac
 subjects:
 - kind: ServiceAccount
   name: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: endpoint-reader
+  name: rabbitmq-peer-discovery-rbac

--- a/minikube/rbac.yaml
+++ b/minikube/rbac.yaml
@@ -14,9 +14,9 @@ rules:
 - apiGroups: [""]
   resources: ["endpoints"]
   verbs: ["get"]
-# - apiGroups: [""]
-#   resources: ["events"]
-#   verbs: ["create"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
In https://github.com/rabbitmq/cluster-operator/issues/264, we observed 403 errors in the RabbitMQ server debug logs.
Does it make sense to therefore add the "create events" rule to these examples?