### PR TITLE
Update statefulset.yaml

### DIFF
--- a/gke/statefulset.yaml
+++ b/gke/statefulset.yaml
@@ -83,7 +83,6 @@ spec:
         - name: rabbitmq-config-rw
           mountPath: "/etc/rabbitmq"
           # mountPath: "/etc/rabbitmq/conf.d/"
-          mountPath: "/var/lib/rabbitmq"
         # rabbitmq data directory
         - name: rabbitmq-data
           mountPath: "/var/lib/rabbitmq/mnesia"


### PR DESCRIPTION
The deleted line line seemed to be an error, it overwrites the mountPath defined directly above it (probably a copy-paste artifact?)

It led to my pods not correctly loading the config specified in the config-map, but rather throwing it into `/var/lib/rabbitmq`, where it was ignored.