### PR TITLE
Rename cluster-links to cluster-rpc

### DIFF
--- a/gke/headless-service.yaml
+++ b/gke/headless-service.yaml
@@ -10,7 +10,7 @@ spec:
     port: 4369
     protocol: TCP
     targetPort: 4369
-  - name: cluster-links
+  - name: cluster-rpc
     port: 25672
     protocol: TCP
     targetPort: 25672


### PR DESCRIPTION
The cluster operator has renamed this service to `cluster-rpc` to clarify the use of the erlang connection, see https://github.com/rabbitmq/cluster-operator/issues/420